### PR TITLE
chore: add clean-package for optimized package management and exclude…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# exclude backup files created by clean-package
+*.backup

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "react-hook-modal",
@@ -13,6 +12,7 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@vitejs/plugin-react": "^5.0.4",
+        "clean-package": "^2.2.0",
         "jsdom": "^27.4.0",
         "typescript": "^5.0.0",
         "vite": "^7.1.9",
@@ -427,6 +427,8 @@
 
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
+    "clean-package": ["clean-package@2.2.0", "", { "dependencies": { "dot-prop": "^6.0.1" }, "bin": { "clean-package": "bin/main.js" } }, "sha512-vLv8kRqvh4smPDpqAYFPLEijTppAd/cfCz4yBcUGoVl/JKu6ZWKhlo+G/cAmwlSa29RudfBeuyiNEzas8bTwEQ=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -472,6 +474,8 @@
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dot-prop": ["dot-prop@6.0.1", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -604,6 +608,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@vitejs/plugin-react": "^5.0.4",
+    "clean-package": "^2.2.0",
     "jsdom": "^27.4.0",
     "typescript": "^5.0.0",
     "vite": "^7.1.9",
@@ -68,6 +69,8 @@
     "build": "vite build",
     "publish:first": "npm publish --access public --provenance false",
     "prepare": "npm run build",
+    "prepack": "clean-package",
+    "postpack": "clean-package restore",
     "dev": "vite",
     "preview": "vite preview",
     "test": "vitest",
@@ -75,6 +78,22 @@
     "changeset": "changeset",
     "version:changeset": "changeset version",
     "publish:changeset": "changeset publish --access public"
+  },
+  "clean-package": {
+    "remove": [
+      "devDependencies",
+      "scripts",
+      "tests",
+      "playwright.config.ts",
+      "tsconfig.json",
+      ".npmignore",
+      ".gitignore",
+      ".vscode",
+      "screenshots",
+      ".changeset",
+      "publishConfig",
+      "clean-package"
+    ]
   },
   "sideEffects": false,
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request introduces the use of the `clean-package` tool to streamline the npm package publishing process by removing unnecessary files and fields from the published package. The changes automate package cleaning before and after packing, and specify exactly which files and fields should be excluded.

**Build and packaging improvements:**

* Added `clean-package` as a development dependency to automate the removal of unnecessary files and fields from the npm package before publishing (`package.json`).
* Added `prepack` and `postpack` scripts to run `clean-package` before and after the npm pack process, ensuring the published package is clean (`package.json`).
* Configured `clean-package` to remove development-related files and fields (such as `devDependencies`, `scripts`, test files, config files, and directories like `.vscode` and `screenshots`) from the published package (`package.json`).

**Project housekeeping:**

* Updated `.npmignore` to exclude backup files created by `clean-package`, preventing accidental publishing of these files. (.npmignore)… backup files