### PR TITLE
feat: implement createPolyfillComponent utility and update Modal comp…

### DIFF
--- a/.changeset/vast-colts-begin.md
+++ b/.changeset/vast-colts-begin.md
@@ -1,0 +1,5 @@
+---
+"@rokku-x/react-hook-modal": patch
+---
+
+feat: implement createPolyfillComponent utility and update Modal components to use it

--- a/src/components/ModalBackdrop.tsx
+++ b/src/components/ModalBackdrop.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 import './ModalBackdrop.css'
+import { createPolyfillComponent } from "@/utils/createPolyfillComponent";
 
-export interface ModalBackdropProps extends React.HTMLAttributes<HTMLDivElement> {
-}
+export interface ModalBackdropProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> { }
 
-export default function ModalBackdrop({ onClick, className = "", style = {}, children }: ModalBackdropProps) {
+function ModalBackdrop({ onClick, className = "", style = {}, children }: ModalBackdropProps) {
     return (
         <div
             className={`hook-modal-backdrop ${className}`}
@@ -15,3 +15,5 @@ export default function ModalBackdrop({ onClick, className = "", style = {}, chi
         </div>
     );
 }
+
+export default createPolyfillComponent(ModalBackdrop) as typeof ModalBackdrop;

--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -1,12 +1,11 @@
 import { stopPropagation } from "@/utils/utils";
 import React from "react";
 import './ModalWindow.css'
+import { createPolyfillComponent } from "@/utils/createPolyfillComponent";
 
-export interface ModalWindowProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ModalWindowProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> { }
 
-}
-
-export default function ModalWindow({ className = "", style = {}, children, ...rest }: ModalWindowProps) {
+function ModalWindow({ className = "", style = {}, children, ...rest }: ModalWindowProps) {
     return (
         <div
             className={`hook-modal-window ${className}`}
@@ -19,3 +18,5 @@ export default function ModalWindow({ className = "", style = {}, children, ...r
         </div>
     );
 }
+
+export default createPolyfillComponent(ModalWindow) as typeof ModalWindow;

--- a/src/utils/createPolyfillComponent.ts
+++ b/src/utils/createPolyfillComponent.ts
@@ -1,0 +1,16 @@
+import React, { forwardRef, ComponentType, ReactElement, Ref } from 'react';
+
+const isReact19 = parseInt(React.version.split('.')[0]) >= 19;
+
+export function createPolyfillComponent<T extends HTMLElement, P = {}>(Component: (props: P & { ref?: Ref<T> }) => ReactElement | null): ComponentType<P & { ref?: Ref<T> }> {
+
+    if (isReact19) return Component as any;
+
+    const Box = forwardRef<T, P>((props, ref) => {
+        return React.createElement(Component, { ...(props as any), ref });
+    });
+
+    Box.displayName = Component.name || 'Component';
+
+    return Box as any;
+}


### PR DESCRIPTION
This pull request introduces a utility to polyfill React 19's new component ref behavior and updates the modal components to use it. Additionally, it improves the CSS injection process in the build pipeline by generating separate CSS entry files for both ESM and CJS builds.

**React 19 Polyfill and Modal Component Updates:**

- Added a new utility function `createPolyfillComponent` in `src/utils/createPolyfillComponent.ts` to ensure compatibility with React 19's ref handling, falling back to `forwardRef` for earlier versions.
- Updated `ModalBackdrop` and `ModalWindow` components to use the new `createPolyfillComponent` utility, ensuring consistent ref behavior across React versions. [[1]](diffhunk://#diff-63d9ea06ee061e22ef64705029da56765faefaa1de589f199960c225e4010404L1-R7) [[2]](diffhunk://#diff-63d9ea06ee061e22ef64705029da56765faefaa1de589f199960c225e4010404R18-R19) [[3]](diffhunk://#diff-d99258f405f3a88d677fc538d65a338a0f76c238b05117d68559edcacd865658R4-R8) [[4]](diffhunk://#diff-d99258f405f3a88d677fc538d65a338a0f76c238b05117d68559edcacd865658R21-R22)

**Build and CSS Injection Improvements:**

- Enhanced the custom Vite plugin in `vite.config.ts` to generate separate CSS-in-JS entry files for both ESM (`index.css.esm.js`) and CJS (`index.css.cjs.js`) builds, and to inject them into the respective JS bundles.

**Changelog:**

- Added a changeset describing the new `createPolyfillComponent` utility and the modal component updates.