### PR TITLE
Feature/multiple renderer instance

### DIFF
--- a/.changeset/all-doodles-sort.md
+++ b/.changeset/all-doodles-sort.md
@@ -1,0 +1,5 @@
+---
+"@rokku-x/react-hook-modal": minor
+---
+
+feat: support multiple BaseModalRenderer instances with isolated stores and update hooks to accept options

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -52,7 +52,7 @@ describe('Integration Tests - Modal Hooks', () => {
 
         it('should handle default content and custom content', () => {
             const { result: baseResult } = renderHook(() => useBaseModalInternal())
-            const { result: staticDefault } = renderHook(() => useStaticModal('Default Content'))
+            const { result: staticDefault } = renderHook(() => useStaticModal({ element: 'Default Content' }))
             const { result: staticCustom } = renderHook(() => useStaticModal())
 
             act(() => {
@@ -222,7 +222,7 @@ describe('Integration Tests - Modal Hooks', () => {
 
         it('should handle stacked modals with updates', () => {
             const { result: baseResult } = renderHook(() => useBaseModalInternal())
-            const { result: static1 } = renderHook(() => useStaticModal('Default 1'))
+            const { result: static1 } = renderHook(() => useStaticModal({ element: 'Default 1' }))
             const { result: static2 } = renderHook(() => useStaticModal())
 
             act(() => {

--- a/src/__tests__/readme-examples.test.tsx
+++ b/src/__tests__/readme-examples.test.tsx
@@ -48,7 +48,7 @@ function WelcomeModalParam() {
             <button onClick={() => closeRef.current()}>Close</button>
         </div>
     )
-    const [showModal, closeModal] = useStaticModal(content)
+    const [showModal, closeModal] = useStaticModal({ element: content })
     useEffect(() => { closeRef.current = closeModal }, [closeModal])
     return <button onClick={() => showModal()}>Show Welcome Modal</button>
 }

--- a/src/components/ModalBackdrop.tsx
+++ b/src/components/ModalBackdrop.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 import './ModalBackdrop.css'
+import { createPolyfillComponent } from "@/utils/createPolyfillComponent";
 
-export interface ModalBackdropProps extends React.HTMLAttributes<HTMLDivElement> {
-}
+export interface ModalBackdropProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> { }
 
-export default function ModalBackdrop({ onClick, className = "", style = {}, children }: ModalBackdropProps) {
+function ModalBackdrop({ onClick, className = "", style = {}, children }: ModalBackdropProps) {
     return (
         <div
             className={`hook-modal-backdrop ${className}`}
@@ -15,3 +15,5 @@ export default function ModalBackdrop({ onClick, className = "", style = {}, chi
         </div>
     );
 }
+
+export default createPolyfillComponent(ModalBackdrop) as typeof ModalBackdrop;

--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -1,12 +1,11 @@
 import { stopPropagation } from "@/utils/utils";
 import React from "react";
 import './ModalWindow.css'
+import { createPolyfillComponent } from "@/utils/createPolyfillComponent";
 
-export interface ModalWindowProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ModalWindowProps extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> { }
 
-}
-
-export default function ModalWindow({ className = "", style = {}, children, ...rest }: ModalWindowProps) {
+function ModalWindow({ className = "", style = {}, children, ...rest }: ModalWindowProps) {
     return (
         <div
             className={`hook-modal-window ${className}`}
@@ -19,3 +18,5 @@ export default function ModalWindow({ className = "", style = {}, children, ...r
         </div>
     );
 }
+
+export default createPolyfillComponent(ModalWindow) as typeof ModalWindow;

--- a/src/hooks/__tests__/useDynamicModal.test.tsx
+++ b/src/hooks/__tests__/useDynamicModal.test.tsx
@@ -195,6 +195,17 @@ describe('useDynamicModal', () => {
         // In jsdom with renderer mounted, returns a React portal
         expect(rendered === null || (rendered as any)?.$$typeof === Symbol.for('react.portal')).toBeTruthy()
     })
+
+    it('should isolate modals by renderer id', () => {
+        render(<><BaseModalRenderer id="r1" /><BaseModalRenderer id="r2" /></>)
+        const { result: d1 } = renderHook(() => useDynamicModal({ rendererId: 'r1' }))
+        const { result: d2 } = renderHook(() => useDynamicModal({ rendererId: 'r2' }))
+        act(() => { d1.current[1]() })
+        const { result: b1 } = renderHook(() => useBaseModal({ rendererId: 'r1' }))
+        const { result: b2 } = renderHook(() => useBaseModal({ rendererId: 'r2' }))
+        expect(b1.current.currentModalId).toBe(d1.current[4])
+        expect(b2.current.currentModalId).toBeUndefined()
+    })
 })
 
 describe('useDynamicModal - Negative Tests', () => {

--- a/src/hooks/__tests__/useStaticModal.test.tsx
+++ b/src/hooks/__tests__/useStaticModal.test.tsx
@@ -44,7 +44,7 @@ describe('useStaticModal', () => {
 
     it('should show default content when provided to hook', () => {
         const defaultContent = 'Default Content'
-        const { result } = renderHook(() => useStaticModal(defaultContent))
+        const { result } = renderHook(() => useStaticModal({ element: defaultContent }))
         const [showModal] = result.current
 
         act(() => {
@@ -90,7 +90,7 @@ describe('useStaticModal', () => {
 
     it('should show provided content over default content', () => {
         const defaultContent = 'Default'
-        const { result } = renderHook(() => useStaticModal(defaultContent))
+        const { result } = renderHook(() => useStaticModal({ element: defaultContent }))
         const [showModal] = result.current
 
         act(() => {
@@ -182,7 +182,7 @@ describe('useStaticModal', () => {
     })
 
     it('should support function as default content', () => {
-        const { result } = renderHook(() => useStaticModal(() => 'Default Rendered'))
+        const { result } = renderHook(() => useStaticModal({ element: () => 'Default Rendered' }))
         const [showModal] = result.current
 
         act(() => {
@@ -250,6 +250,19 @@ describe('useStaticModal', () => {
         })
 
         expect(result.current[0]).toBeDefined()
+    })
+
+    it('should isolate stores by renderer id', () => {
+        render(<><BaseModalRenderer id="r1" /><BaseModalRenderer id="r2" /></>)
+        const { result: s1 } = renderHook(() => useStaticModal({ rendererId: 'r1' }))
+        const { result: s2 } = renderHook(() => useStaticModal({ rendererId: 'r2' }))
+        const { result: b1 } = renderHook(() => useBaseModal({ rendererId: 'r1' }))
+        const { result: b2 } = renderHook(() => useBaseModal({ rendererId: 'r2' }))
+        act(() => {
+            s1.current[0]('r1-content')
+        })
+        expect(b1.current.currentModalId).toBe(s1.current[4])
+        expect(b2.current.currentModalId).toBeUndefined()
     })
 })
 

--- a/src/hooks/useBaseModal.ts
+++ b/src/hooks/useBaseModal.ts
@@ -1,25 +1,31 @@
 'use client'
 
-import storeBaseModal from '../store/modal'
+import storeInstanceBaseModal from '../store/modal'
 import { RenderMode } from '../types/modal'
-import type { Store } from '../store/modal'
+import type { BaseModalStoreInstance, Store } from '../store/modal'
 import type { ModalStackMapType } from '../types/modal'
 export { RenderMode } from '../types/modal'
 export type { AcceptableElement, ModalEntry } from '../types/modal'
 
+export type useBaseModalOptions = {
+    rendererId?: string
+}
 /**
  * Primary hook for interacting with the modal store.
  *
  * Provides actions to push/pop/update/focus modals along with state access for
  * `currentModalId` and `renderMode`.
  *
+ * @param rendererId Optional ID of the `BaseModalRenderer` to use; defaults to the default renderer.
+ *                 The `rendererId` should match the `id` prop of a mounted `BaseModalRenderer` to target that renderer's store.
  * @returns An object with modal actions and state.
  * @example
  * const { pushModal, popModal } = useBaseModal()
  * pushModal('my-id', <div>Content</div>)
  * popModal('my-id')
  */
-export default function useBaseModal(): Store['actions'] & { currentModalId?: string; renderMode: RenderMode } {
+export default function useBaseModal({ rendererId = "default" }: useBaseModalOptions = {}): Store['actions'] & { currentModalId?: string; renderMode: RenderMode } {
+    const storeBaseModal = storeInstanceBaseModal(rendererId);
     const { actions, currentModalId, renderMode } = storeBaseModal((state) => state)
     return { ...actions, currentModalId, renderMode };
 }
@@ -27,17 +33,22 @@ export default function useBaseModal(): Store['actions'] & { currentModalId?: st
 /**
  * Internal hook for advanced operations and direct store access.
  *
+ * @param rendererId Optional ID of the `BaseModalRenderer` to use; defaults to the default renderer.
+ * @returns An object with internal actions and full store data.
+ *
+ * @remarks
  * Exposes internal actions and raw store data, useful for testing, debugging,
  * and renderer integration.
  */
-export function useBaseModalInternal(): Store['internalActions'] & {
+export function useBaseModalInternal({ rendererId = "default" }: useBaseModalOptions = {}): Store['internalActions'] & {
     isMounted: boolean;
     modalStackMap: ModalStackMapType;
     modalWindowRefs?: Map<string, HTMLDivElement>;
     currentModalId?: string;
     renderMode: RenderMode;
-    store: typeof storeBaseModal;
+    store: BaseModalStoreInstance;
 } {
+    const storeBaseModal = storeInstanceBaseModal(rendererId);
     const { internalActions, isMounted, modalStackMap, modalWindowRefs, currentModalId, renderMode } = storeBaseModal((state) => state)
     return { ...internalActions, isMounted, modalStackMap, modalWindowRefs, currentModalId, renderMode, store: storeBaseModal };
 }

--- a/src/hooks/useDynamicModal.ts
+++ b/src/hooks/useDynamicModal.ts
@@ -9,14 +9,18 @@ export { RenderMode };
 
 /** Function returned by `useDynamicModal` to render content inside the modal window via a portal. */
 export type RenderModalElementFn = (el: ReactNode) => ReactNode;
-/** Function returned by `useDynamicModal` to open the modal. */
-export type ShowDynamicModalFn = () => void;
+/** Function returned by `useDynamicModal` to open the modal. Returns the modal id string. */
+export type ShowDynamicModalFn = () => string;
 /** Function returned by `useDynamicModal` to close the modal. */
 export type CloseDynamicModalFn = () => boolean;
 /** Function returned by `useDynamicModal` to focus the modal to foreground. */
 export type FocusDynamicModalFn = () => boolean;
 /** Tuple returned by `useDynamicModal`. */
 export type UseDynamicModalReturn = [RenderModalElementFn, ShowDynamicModalFn, CloseDynamicModalFn, FocusDynamicModalFn, string, boolean];
+/** Options for `useDynamicModal`. */
+export type UseDynamicModalOptions = {
+    rendererId?: string;
+}
 
 /**
  * Hook for dynamic modals where content is rendered from within the modal window.
@@ -25,6 +29,7 @@ export type UseDynamicModalReturn = [RenderModalElementFn, ShowDynamicModalFn, C
  * rendered into the modal window using a React portal. Requires a mounted
  * `BaseModalRenderer` so the window ref exists.
  *
+ * @param rendererId Optional ID of the `BaseModalRenderer` to use; defaults to the default renderer.
  * @returns `[renderModalElement, showModal, closeModal, focus, id, isForeground]`
  * @example
  * const [render, show, close] = useDynamicModal()
@@ -33,9 +38,9 @@ export type UseDynamicModalReturn = [RenderModalElementFn, ShowDynamicModalFn, C
  *   {render(<div><button onClick={close}>Close</button></div>)}
  * </>)
  */
-export default function useDynamicModal(): UseDynamicModalReturn {
+export default function useDynamicModal({ rendererId }: UseDynamicModalOptions = {}): UseDynamicModalReturn {
     const id: string = useId();
-    const { pushModal, popModal, focusModal, getModalWindowRef, currentModalId } = useBaseModal();
+    const { pushModal, popModal, focusModal, getModalWindowRef, currentModalId } = useBaseModal({ rendererId });
     const [, setRerender] = useState(0);
     const isForeground = currentModalId === id;
 

--- a/src/hooks/useStaticModal.ts
+++ b/src/hooks/useStaticModal.ts
@@ -25,21 +25,26 @@ export type FocusStaticModalFn = (customId?: string) => boolean;
 export type UpdateModalContentFn = (newContent: AcceptableElement, customId?: string) => boolean;
 /** Tuple returned by `useStaticModal`. */
 export type UseStaticModalReturn = [ShowModalFn, CloseModalFn, FocusStaticModalFn, UpdateModalContentFn, string];
-
+/** Options for `useStaticModal`. */
+export type UseStaticModalOptions = {
+    element?: AcceptableElement;
+    rendererId?: string;
+}
 /**
  * Hook for displaying static modal content.
  *
  * Static modals render content provided at open time (or via the hook parameter).
  *
  * @param element Optional default content to use when calling `showModal()` without arguments.
+ * @param rendererId Optional ID of the `BaseModalRenderer` to use; defaults to the default renderer.
  * @returns `[showModal, closeModal, focus, updateModalContent, id]`
  * @example
  * const [show, close, focus, updateModalContent, id] = useStaticModal()
  * <button onClick={() => show(<div>Hi</div>)}>Open</button>
  */
-export default function useStaticModal(element?: AcceptableElement): UseStaticModalReturn {
+export default function useStaticModal({ element, rendererId }: UseStaticModalOptions = {}): UseStaticModalReturn {
     const id: string = useId();
-    const { pushModal, popModal, updateModal, focusModal } = useBaseModal();
+    const { pushModal, popModal, updateModal, focusModal } = useBaseModal({ rendererId });
 
     const showModal: ShowModalFn = (el?: AcceptableElement, sId: boolean | string = id) => {
         let instanceId = typeof sId === "string" ? sId : sId === true ? randomId(4) : id;

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -42,87 +42,96 @@ export interface Store {
     }
 }
 
-
-const storeBaseModal = create<Store>()((set, get) => ({
-    modalStackMap: new Map(),
-    isMounted: false,
-    renderMode: RenderMode.STACKED,
-    modalWindowRefs: undefined,
-    currentModalId: undefined,
-    internalActions: {
-        setModalWindowRefRef: (map?: Map<string, HTMLDivElement>) => set((state) => {
-            return { modalWindowRefs: map };
-        }),
-        setIsMounted: (mounted: boolean) => set({ isMounted: mounted }),
-        setRenderMode: (mode: RenderMode) => set({ renderMode: mode }),
-    },
-    actions: {
-        pushModal: (modalId: string | undefined, el: AcceptableElement, isDynamic: boolean = false) => {
-            modalId = modalId ?? Math.random().toString(36).substring(2, 6);
-            if (!get().isMounted) console.warn("BaseModalRenderer must be mounted before using. Please add <BaseModalRenderer /> to your component tree.");
-            const modal = get().modalStackMap.get(modalId);
-            if (modal !== undefined) {
-                get().actions.focusModal(modalId);
-                return modalId;
-            }
-            set((state) => {
-                let item: [AcceptableElement | null, boolean] = [el, isDynamic];
-                const newMap = new Map(state.modalStackMap);
-                newMap.set(modalId, item);
-                return { modalStackMap: newMap, currentModalId: modalId };
-            });
-            return modalId
+function createStore(instanceId: string = "default") {
+    return create<Store>()((set, get) => ({
+        modalStackMap: new Map(),
+        isMounted: false,
+        renderMode: RenderMode.STACKED,
+        modalWindowRefs: undefined,
+        currentModalId: undefined,
+        internalActions: {
+            setModalWindowRefRef: (map?: Map<string, HTMLDivElement>) => set((state) => {
+                return { modalWindowRefs: map };
+            }),
+            setIsMounted: (mounted: boolean) => set({ isMounted: mounted }),
+            setRenderMode: (mode: RenderMode) => set({ renderMode: mode }),
         },
-        popModal: (modalId: string) => {
-            const modal = get().modalStackMap.get(modalId);
-            if (!modal) return false;
-            set((state) => {
-                const newMap = new Map(state.modalStackMap);
-                newMap.delete(modalId);
-                const lastModalId = Array.from(newMap.keys())[newMap.size - 1];
-                return { modalStackMap: newMap, currentModalId: lastModalId };
-            });
-            return true
-        },
-        getModal: (modalId: string) => {
-            return get().modalStackMap.get(modalId);
-        },
-        updateModal: (modalId: string, newContent: AcceptableElement, isDynamic?: boolean) => {
-            const modal = get().modalStackMap.get(modalId);
-            if (!modal) return false;
-            set((state) => {
-                const newMap = new Map(state.modalStackMap);
-                //throw error if not dynamic
-                if (modal[1] === true) {
-                    console.warn(`Modal with id ${modalId} is dynamic. Cannot update content.`);
-                    return { modalStackMap: state.modalStackMap };
+        actions: {
+            pushModal: (modalId: string | undefined, el: AcceptableElement, isDynamic: boolean = false) => {
+                modalId = modalId ?? Math.random().toString(36).substring(2, 6);
+                if (!get().isMounted) console.warn("BaseModalRenderer must be mounted before using. Please add <BaseModalRenderer /> to your component tree.");
+                const modal = get().modalStackMap.get(modalId);
+                if (modal !== undefined) {
+                    get().actions.focusModal(modalId);
+                    return modalId;
                 }
-                modal[0] = newContent;
-                modal[1] = isDynamic ?? modal[1];
-                newMap.set(modalId, modal);
-                return { modalStackMap: newMap };
-            })
-            return true
-        },
-        focusModal: (modalId: string) => {
-            const item = get().modalStackMap.get(modalId);
-            if (!item) return false;
-            set((state) => {
-                const newMap = new Map(state.modalStackMap);
-                newMap.delete(modalId);
-                newMap.set(modalId, item);
-                return { modalStackMap: newMap, currentModalId: modalId };
-            })
-            return true;
-        },
-        getModalOrderIndex: (modalId: string) => {
-            const keys = Array.from(get().modalStackMap.keys());
-            return keys.indexOf(modalId);
-        },
-        getModalWindowRef: (modalId: string) => {
-            return get().modalWindowRefs?.get(modalId);
+                set((state) => {
+                    let item: [AcceptableElement | null, boolean] = [el, isDynamic];
+                    const newMap = new Map(state.modalStackMap);
+                    newMap.set(modalId, item);
+                    return { modalStackMap: newMap, currentModalId: modalId };
+                });
+                return modalId
+            },
+            popModal: (modalId: string) => {
+                const modal = get().modalStackMap.get(modalId);
+                if (!modal) return false;
+                set((state) => {
+                    const newMap = new Map(state.modalStackMap);
+                    newMap.delete(modalId);
+                    const lastModalId = Array.from(newMap.keys())[newMap.size - 1];
+                    return { modalStackMap: newMap, currentModalId: lastModalId };
+                });
+                return true
+            },
+            getModal: (modalId: string) => {
+                return get().modalStackMap.get(modalId);
+            },
+            updateModal: (modalId: string, newContent: AcceptableElement, isDynamic?: boolean) => {
+                const modal = get().modalStackMap.get(modalId);
+                if (!modal) return false;
+                set((state) => {
+                    const newMap = new Map(state.modalStackMap);
+                    //throw error if not dynamic
+                    if (modal[1] === true) {
+                        console.warn(`Modal with id ${modalId} is dynamic. Cannot update content.`);
+                        return { modalStackMap: state.modalStackMap };
+                    }
+                    modal[0] = newContent;
+                    modal[1] = isDynamic ?? modal[1];
+                    newMap.set(modalId, modal);
+                    return { modalStackMap: newMap };
+                })
+                return true
+            },
+            focusModal: (modalId: string) => {
+                const item = get().modalStackMap.get(modalId);
+                if (!item) return false;
+                set((state) => {
+                    const newMap = new Map(state.modalStackMap);
+                    newMap.delete(modalId);
+                    newMap.set(modalId, item);
+                    return { modalStackMap: newMap, currentModalId: modalId };
+                })
+                return true;
+            },
+            getModalOrderIndex: (modalId: string) => {
+                const keys = Array.from(get().modalStackMap.keys());
+                return keys.indexOf(modalId);
+            },
+            getModalWindowRef: (modalId: string) => {
+                return get().modalWindowRefs?.get(modalId);
+            }
         }
-    }
-}));
+    }));
+}
 
-export default storeBaseModal;
+const storeMap = new Map<string, ReturnType<typeof createStore>>();
+
+export type BaseModalStoreInstance = ReturnType<typeof createStore>;
+
+export default function (instanceId: string = "default"): BaseModalStoreInstance {
+    if (!storeMap.has(instanceId)) storeMap.set(instanceId, createStore(instanceId));
+    return storeMap.get(instanceId)! as BaseModalStoreInstance;
+}
+

--- a/src/utils/createPolyfillComponent.ts
+++ b/src/utils/createPolyfillComponent.ts
@@ -1,0 +1,16 @@
+import React, { forwardRef, ComponentType, ReactElement, Ref } from 'react';
+
+const isReact19 = parseInt(React.version.split('.')[0]) >= 19;
+
+export function createPolyfillComponent<T extends HTMLElement, P = {}>(Component: (props: P & { ref?: Ref<T> }) => ReactElement | null): ComponentType<P & { ref?: Ref<T> }> {
+
+    if (isReact19) return Component as any;
+
+    const Box = forwardRef<T, P>((props, ref) => {
+        return React.createElement(Component, { ...(props as any), ref });
+    });
+
+    Box.displayName = Component.name || 'Component';
+
+    return Box as any;
+}


### PR DESCRIPTION
This pull request adds support for multiple `BaseModalRenderer` instances, each with its own isolated modal store, allowing different parts of an application to manage modals independently. The hooks (`useStaticModal`, `useDynamicModal`, and `useBaseModal`) are updated to accept a `rendererId` option, enabling them to target specific renderer instances. The documentation, tests, and component implementations are updated to reflect and verify these changes.

**Multi-Renderer and Store Isolation Enhancements:**

* `BaseModalRenderer` now supports multiple instances, each identified by a unique `id`, and throws an error if duplicate `id`s are mounted. Each renderer uses an isolated modal store keyed by `id`. [[1]](diffhunk://#diff-0c5cdff81f3f93ea94df3738d4ac85ed3479681b3d6c0ce6569ea94541824efdL8-R19) [[2]](diffhunk://#diff-0c5cdff81f3f93ea94df3738d4ac85ed3479681b3d6c0ce6569ea94541824efdL47-R57)
* All modal hooks (`useStaticModal`, `useDynamicModal`, `useBaseModal`) accept a `rendererId` option to target a specific renderer's store, ensuring modal actions are isolated per renderer. [[1]](diffhunk://#diff-ef36c31e04ca38881806f6282ce81627d384336fda0b165f2d2245a1f057ff07R1-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R56) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R87) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R260)

**Documentation Updates:**

* The `README.md` is updated to document the new multi-renderer support, updated hook APIs, and usage examples for targeting specific renderer instances. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R56) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R87) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L198-R260) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L280-R317)

**Testing Improvements:**

* New and updated tests verify that multiple renderers can be mounted, that duplicate `id`s throw errors, and that modal stores and actions are isolated per renderer instance. [[1]](diffhunk://#diff-4a97c5bd2e38a46611ed8759cd43f179884aa18fdb016422a799d49d9680c18dL166-R196) [[2]](diffhunk://#diff-9244593a9df5acd89ba3ba78b096ea7d64a1da8c85d5f15f1c9492a30976835cR198-R208) [[3]](diffhunk://#diff-90ab96638d7a2130d41afe135631af1e377a202e8737ccc14010e8f28fa6683eR254-R266)

**API and Usage Consistency:**

* The `useStaticModal` hook API is standardized to accept an options object (with `element` and `rendererId`), and all usages and tests are updated accordingly. [[1]](diffhunk://#diff-9cf1fdacc780ea74cb9703df9af4c79dd01382aec916b139e6baa0fde24f45aeL55-R55) [[2]](diffhunk://#diff-9cf1fdacc780ea74cb9703df9af4c79dd01382aec916b139e6baa0fde24f45aeL225-R225) [[3]](diffhunk://#diff-40fc06eac50fc98788858584df40618548151cfcf923a8fd13b7ab1389377158L51-R51) [[4]](diffhunk://#diff-90ab96638d7a2130d41afe135631af1e377a202e8737ccc14010e8f28fa6683eL47-R47) [[5]](diffhunk://#diff-90ab96638d7a2130d41afe135631af1e377a202e8737ccc14010e8f28fa6683eL93-R93) [[6]](diffhunk://#diff-90ab96638d7a2130d41afe135631af1e377a202e8737ccc14010e8f28fa6683eL185-R185)

**Component Improvements:**

* `ModalBackdrop` and `ModalWindow` are refactored to use `createPolyfillComponent` and have more precise TypeScript typings. [[1]](diffhunk://#diff-63d9ea06ee061e22ef64705029da56765faefaa1de589f199960c225e4010404L1-R7) [[2]](diffhunk://#diff-63d9ea06ee061e22ef64705029da56765faefaa1de589f199960c225e4010404R18-R19) [[3]](diffhunk://#diff-d99258f405f3a88d677fc538d65a338a0f76c238b05117d68559edcacd865658R4-R8) [[4]](diffhunk://#diff-d99258f405f3a88d677fc538d65a338a0f76c238b05117d68559edcacd865658R21-R22)

closes #19 