### PR TITLE
fix: add wildcard for CSS file side effects in package.json

### DIFF
--- a/.changeset/lucky-bags-switch.md
+++ b/.changeset/lucky-bags-switch.md
@@ -1,0 +1,5 @@
+---
+"@rokku-x/react-hook-modal": patch
+---
+
+fix: add wildcard for CSS file side effects in package.json

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   },
   "sideEffects": [
     "*.css",
+    "*.css*",
     "*.scss"
   ],
   "typesVersions": {


### PR DESCRIPTION
This pull request addresses a packaging issue by updating the handling of CSS file side effects in the project. The main change ensures that all CSS-related files are correctly recognized as side effects, which helps prevent accidental removal during tree-shaking and improves compatibility with build tools.

Packaging and build improvements:

* Updated the `sideEffects` array in `package.json` to include a wildcard pattern for CSS files (`*.css*`), ensuring that files like `.css`, `.css.map`, and other variations are properly handled.
* Added a changeset entry to document the patch fix for CSS file side effects in `@rokku-x/react-hook-modal`.